### PR TITLE
Add Yugoslavia

### DIFF
--- a/lib/iso_country_codes/calling.rb
+++ b/lib/iso_country_codes/calling.rb
@@ -747,5 +747,8 @@ class IsoCountryCodes
     class GNB < Code #:nodoc:
       self.calling = '+245'
     end
+    class YUG < Code #:nodoc:
+      self.calling = '+38'
+    end
   end # end Code
 end # IsoCountryCodes

--- a/lib/iso_country_codes/continent.rb
+++ b/lib/iso_country_codes/continent.rb
@@ -737,5 +737,8 @@ class IsoCountryCodes
     class ZWE < Code #:nodoc:
       self.continent = 'AF'
     end
+    class YUG < Code #:nodoc:
+      self.continent = 'EU'
+    end
   end
 end

--- a/lib/iso_country_codes/iso_3166_1.rb
+++ b/lib/iso_country_codes/iso_3166_1.rb
@@ -1496,6 +1496,12 @@ class IsoCountryCodes
       self.alpha2  = %q{ZW}
       self.alpha3  = %q{ZWE}
     end
+    class YUG < Code #:nodoc:
+      self.numeric = %q{891}
+      self.name    = %q{Yugoslavia}
+      self.alpha2  = %q{YU}
+      self.alpha3  = %q{YUG}
+    end
   end # end Code
 end # IsoCountryCodes
 


### PR DESCRIPTION
There is a problem in Gatherer because we have no Country iso 3 code for Yugoslavia in Reticulum:

![image](https://user-images.githubusercontent.com/1818778/104582507-420e1380-5660-11eb-9f42-35abe4500a93.png)

And Reticulum reads from CIAO and CIAO from this gem. Right now we have this information in CIAO:

![image](https://user-images.githubusercontent.com/1818778/104583056-f60f9e80-5660-11eb-9419-9d2737bcf944.png)

To get this in CIAO:

![image](https://user-images.githubusercontent.com/1818778/104583110-0a539b80-5661-11eb-936f-44043bd88e44.png)

We need to apply this change to the gem and update the gem in CIAO.
